### PR TITLE
Update default kernel and distribution

### DIFF
--- a/linode.go
+++ b/linode.go
@@ -129,7 +129,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			EnvVar: "LINODE_DOCKER_PORT",
 			Name:   "linode-docker-port",
 			Usage:  "Docker Port",
-			Value:  2375,
+			Value:  2376,
 		},
 	}
 }

--- a/linode.go
+++ b/linode.go
@@ -117,13 +117,13 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			EnvVar: "LINODE_DISTRIBUTION_ID",
 			Name:   "linode-distribution-id",
 			Usage:  "Linode Distribution Id",
-			Value:  124, // Ubuntu 14.04 LTS
+			Value:  140, // Debian 8 (Ubuntu 16.04 LTD = 146)
 		},
 		mcnflag.IntFlag{
 			EnvVar: "LINODE_KERNEL_ID",
 			Name:   "linode-kernel-id",
 			Usage:  "Linode Kernel Id",
-			Value:  226, // default kernel, Latest 64 bit (4.1.5-x86_64-linode61),
+			Value:  210, // default kernel, GRUB 2,
 		},
 		mcnflag.IntFlag{
 			EnvVar: "LINODE_DOCKER_PORT",


### PR DESCRIPTION
Use GRUB 2 and Debian 8 by default. Fixes #3 and #4