### PR TITLE
Updated primary disk size to be 20480

### DIFF
--- a/linode.go
+++ b/linode.go
@@ -226,7 +226,7 @@ func (d *Driver) Create() error {
 	distributionId := d.DistributionId
 
 	log.Debug("Create disk")
-	createDiskJobResponse, err := d.client.Disk.CreateFromDistribution(distributionId, d.LinodeId, "Primary Disk", 24576-256, args)
+	createDiskJobResponse, err := d.client.Disk.CreateFromDistribution(distributionId, d.LinodeId, "Primary Disk", 20480-256, args)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
Problem: You can't create a node via docker-machine because of the disk size.
Solution: Lower the disk size to be in accordance with what Linode has